### PR TITLE
[fix] add export of cli arguments

### DIFF
--- a/include/tdl/Param.h
+++ b/include/tdl/Param.h
@@ -507,6 +507,23 @@ namespace tdl
     void setMaxFloat(const std::string& key, double max);
     //!\}
 
+
+    /*!\brief Set the cli mapping from a key to the required parameter on the command line
+     * \param key             name of the key as used in e.g. setValue
+     * \param cliArgumentName identifier used before the name on a cli. This can be empty in case of positional arguments.
+     */
+    void setCliMapping(std::string const& key, std::string const& cliArgumentName) {
+        cliMapping[key] = cliArgumentName;
+    }
+
+    /*!\brief Access to the CLI Mapping.
+     * \return returns a mapping from  a key to a cli argument parameter.
+     */
+    auto getCliMapping() const -> auto const&
+    {
+        return cliMapping;
+    }
+
     /*!\name Command line parsing
      * \{
      */
@@ -552,6 +569,9 @@ namespace tdl
 
     //!\brief Invisible root node that stores all the data.
     mutable Param::ParamNode root_{"ROOT", ""};
+
+    //!\brief Maps a key to an cli argument;
+    std::map<std::string, std::string> cliMapping;
   };
 
   //!\brief Formatted output.

--- a/include/tdl/ParamCTDFile.h
+++ b/include/tdl/ParamCTDFile.h
@@ -396,8 +396,21 @@ namespace tdl
         os << std::string(indentations, ' ') << "</NODE>\n";
       }
     }
-
     os << "</PARAMETERS>\n";
+
+    // Print cli mapping, if available
+    if (param.getCliMapping().size() > 0)
+    {
+        os << "  <CLI>\n";
+        for (auto const& [name, argument] : param.getCliMapping())
+        {
+            os << "    <CLIELEMENT optionIdentifier=\"" + argument + "\">\n";
+            os << "      <MAPPING referenceName=\"" + name + "\" />\n";
+            os << "    </CLIELEMENT>\n";
+        }
+        os << "  </CLI>\n";
+    }
+
     os << "</tool>" << std::endl; //forces a flush
   }
   //!\endcond

--- a/test/ParamCTDFile_test.cpp
+++ b/test/ParamCTDFile_test.cpp
@@ -24,6 +24,7 @@ protected:
     p.setValue("test2:int",18);
     p.setSectionDescription("test","sectiondesc");
     p.addTags("test:float", {"a","b","c"});
+    p.setCliMapping("test", "--test");
   }
 };
 
@@ -77,6 +78,11 @@ TEST_F(ParamCTDFileF, store) {
     </NODE>
   </NODE>
 </PARAMETERS>
+  <CLI>
+    <CLIELEMENT optionIdentifier="--test">
+      <MAPPING referenceName="test" />
+    </CLIELEMENT>
+  </CLI>
 </tool>
 )");
   }


### PR DESCRIPTION
Add function to export internal names to the actual arguments required to set the parameter on the command line.