### PR TITLE
Fix/full double precsion

### DIFF
--- a/include/tdl/ParamValue.h
+++ b/include/tdl/ParamValue.h
@@ -1138,7 +1138,7 @@ namespace tdl
     std::string s;
     if (full_precision)
     {
-      os.precision(15);
+      os.precision(std::numeric_limits<double>::max_digits10);
     }
     else
     {


### PR DESCRIPTION
Small double precision issue.

Comment from the commit:
While 15 is the correct number of digits required to represent a
    double, it misses the separation point (.) and the potential sign (+/-).
    This is reflected in std::numeric_limits<double>::max_digits10 which
    returns 17. (Or if ever used for floats, it would return 9.)
