### PR TITLE
Patch/prettier types

### DIFF
--- a/src/tdl/ParamDocumentToCTD.h
+++ b/src/tdl/ParamDocumentToCTD.h
@@ -167,7 +167,7 @@ inline auto convertToCTD(Node const& param) -> XMLNode {
 
     auto tags = param.tags; // copy tags to make them mutable
 
-    // fill xmlNode depending on the actuall type
+    // fill xmlNode depending on the actual type
     std::visit(overloaded{
         [&](BoolValue value) {
             xmlNode.tag = "ITEM";

--- a/src/tdl/ParamDocumentToCWL.h
+++ b/src/tdl/ParamDocumentToCWL.h
@@ -248,15 +248,25 @@ inline auto convertToCWL(ToolInfo const& doc) -> std::string {
 
     auto y = toYaml(tool);
 
-    // Post procssing the yaml document
-    // 1. Collapsing optional scalar types into one option
-    for (auto input : y["inputs"]) {
-        auto type = input["type"];
-        if (type.IsSequence() and type.size() == 2) {
-            if (type[0].IsScalar()
-                and type[0].as<std::string>() == "null"
-                and type[1].IsScalar()) {
-                type = type[1].as<std::string>() + "?";
+    // Post procssing inputs and outputs of the yaml object
+    for (auto param : {"inputs", "outputs"}) {
+        for (auto input : y[param]) {
+            auto type = input["type"];
+
+            // 1. Collapsing optional scalar types into one option
+            if (type.IsSequence() and type.size() == 2) {
+                if (type[0].IsScalar()
+                    and type[0].as<std::string>() == "null"
+                    and type[1].IsScalar()) {
+                    type = type[1].as<std::string>() + "?";
+                }
+            }
+
+            // 2. Collapsing array types into one option
+            if (type.IsMap()
+                and type["type"].as<std::string>() == "array"
+                and type["items"].IsScalar()) {
+                type = type["items"].as<std::string>() + "[]";
             }
         }
     }

--- a/src/tdl/ParamDocumentToCWL.h
+++ b/src/tdl/ParamDocumentToCWL.h
@@ -41,7 +41,7 @@ namespace cwl = https___w3id_org_cwl_cwl;
 /**!\brief a global callback function to adjust the exporting for cwl
  *
  * This callback allows to adjust the exported yaml file to add/change/remove
- * cwl entries, which currently arn't controllable via tdl itself.
+ * cwl entries, which currently aren't controllable via tdl itself.
  */
 inline std::function<void(YAML::Node&)> post_process_cwl;
 

--- a/src/tdl/ParamDocumentToCWL.h
+++ b/src/tdl/ParamDocumentToCWL.h
@@ -246,8 +246,20 @@ inline auto convertToCWL(ToolInfo const& doc) -> std::string {
     }
     tool.baseCommand = baseCommand;
 
-
     auto y = toYaml(tool);
+
+    // Post procssing the yaml document
+    // 1. Collapsing optional scalar types into one option
+    for (auto input : y["inputs"]) {
+        auto type = input["type"];
+        if (type.IsSequence() and type.size() == 2) {
+            if (type[0].IsScalar()
+                and type[0].as<std::string>() == "null"
+                and type[1].IsScalar()) {
+                type = type[1].as<std::string>() + "?";
+            }
+        }
+    }
 
     // post process generated cwl yaml file
     if (post_process_cwl) {

--- a/src/tdl/ParamDocumentToCWL.h
+++ b/src/tdl/ParamDocumentToCWL.h
@@ -268,6 +268,18 @@ inline auto convertToCWL(ToolInfo const& doc) -> std::string {
                 and type["items"].IsScalar()) {
                 type = type["items"].as<std::string>() + "[]";
             }
+
+            // 3. Collapsing optional array types into one option
+            if (type.IsSequence() and type.size() == 2) {
+                if (type[0].IsScalar()
+                    and type[0].as<std::string>() == "null"
+                    and type[1].IsMap()
+                    and type[1]["type"].as<std::string>() == "array"
+                    and type[1]["items"].IsScalar()) {
+                    type = type[1]["items"].as<std::string>() + "[]?";
+                }
+            }
+
         }
     }
 

--- a/src/test_tdl/ParamDocumentToCWL_test.cpp
+++ b/src/test_tdl/ParamDocumentToCWL_test.cpp
@@ -137,19 +137,25 @@ void testComplexCall() {
                            CPP20(.tags        =) {},
                            CPP20(.value       =) tdl::StringValue{}
                },
+               tdl::Node{CPP20(.name        =) "optional_multi_input_file",
+                            CPP20(.description =) "no doc",
+                            CPP20(.tags        =) {"input", "file"},
+                            CPP20(.value       =) tdl::StringValueList{}
+               },
             },
             CPP20(.cliMapping =) {
-                {CPP20(.optionIdentifier =) "",                         CPP20(.referenceName =) "command"},
-                {CPP20(.optionIdentifier =) "--kmer",                   CPP20(.referenceName =) "kmer"},
-                {CPP20(.optionIdentifier =) "--window",                 CPP20(.referenceName =) "window"},
-                {CPP20(.optionIdentifier =) "--single_input_file",      CPP20(.referenceName =) "single_input_file"},
-                {CPP20(.optionIdentifier =) "--multi_input_file",       CPP20(.referenceName =) "multi_input_file"},
-                {CPP20(.optionIdentifier =) "--single_input_directory", CPP20(.referenceName =) "single_input_directory"},
-                {CPP20(.optionIdentifier =) "--single_output_file",     CPP20(.referenceName =) "single_output_file"},
-                {CPP20(.optionIdentifier =) "--prefixed_output_file" ,  CPP20(.referenceName =) "prefixed_output_file"},
-                {CPP20(.optionIdentifier =) "--prefixed_output_files",  CPP20(.referenceName =) "prefixed_output_files"},
-                {CPP20(.optionIdentifier =) "--single_output_dir",      CPP20(.referenceName =) "single_output_dir"},
-                {CPP20(.optionIdentifier =) "--optional_param1",        CPP20(.referenceName =) "optional_param1"},
+                {CPP20(.optionIdentifier =) "",                            CPP20(.referenceName =) "command"},
+                {CPP20(.optionIdentifier =) "--kmer",                      CPP20(.referenceName =) "kmer"},
+                {CPP20(.optionIdentifier =) "--window",                    CPP20(.referenceName =) "window"},
+                {CPP20(.optionIdentifier =) "--single_input_file",         CPP20(.referenceName =) "single_input_file"},
+                {CPP20(.optionIdentifier =) "--multi_input_file",          CPP20(.referenceName =) "multi_input_file"},
+                {CPP20(.optionIdentifier =) "--single_input_directory",    CPP20(.referenceName =) "single_input_directory"},
+                {CPP20(.optionIdentifier =) "--single_output_file",        CPP20(.referenceName =) "single_output_file"},
+                {CPP20(.optionIdentifier =) "--prefixed_output_file" ,     CPP20(.referenceName =) "prefixed_output_file"},
+                {CPP20(.optionIdentifier =) "--prefixed_output_files",     CPP20(.referenceName =) "prefixed_output_files"},
+                {CPP20(.optionIdentifier =) "--single_output_dir",         CPP20(.referenceName =) "single_output_dir"},
+                {CPP20(.optionIdentifier =) "--optional_param1",           CPP20(.referenceName =) "optional_param1"},
+                {CPP20(.optionIdentifier =) "--optional_multi_input_file", CPP20(.referenceName =) "optional_multi_input_file"},
             },
         });
         auto expected = std::string{R"(inputs:
@@ -203,6 +209,11 @@ void testComplexCall() {
     type: string?
     inputBinding:
       prefix: --optional_param1
+  - doc: no doc
+    id: optional_multi_input_file
+    type: File[]?
+    inputBinding:
+      prefix: --optional_multi_input_file
 outputs:
   - id: single_output_file
     type: File

--- a/src/test_tdl/ParamDocumentToCWL_test.cpp
+++ b/src/test_tdl/ParamDocumentToCWL_test.cpp
@@ -132,6 +132,11 @@ void testComplexCall() {
                             CPP20(.tags        =) {"output", "required", "directory"},
                             CPP20(.value       =) tdl::StringValue{}
                },
+               tdl::Node{CPP20(.name        =) "optional_param1",
+                           CPP20(.description =) "no doc",
+                           CPP20(.tags        =) {},
+                           CPP20(.value       =) tdl::StringValue{}
+               },
             },
             CPP20(.cliMapping =) {
                 {CPP20(.optionIdentifier =) "",                         CPP20(.referenceName =) "command"},
@@ -144,6 +149,7 @@ void testComplexCall() {
                 {CPP20(.optionIdentifier =) "--prefixed_output_file" ,  CPP20(.referenceName =) "prefixed_output_file"},
                 {CPP20(.optionIdentifier =) "--prefixed_output_files",  CPP20(.referenceName =) "prefixed_output_files"},
                 {CPP20(.optionIdentifier =) "--single_output_dir",      CPP20(.referenceName =) "single_output_dir"},
+                {CPP20(.optionIdentifier =) "--optional_param1",        CPP20(.referenceName =) "optional_param1"},
             },
         });
         auto expected = std::string{R"(inputs:
@@ -194,6 +200,11 @@ void testComplexCall() {
     type: string
     inputBinding:
       prefix: --single_output_dir
+  - doc: no doc
+    id: optional_param1
+    type: string?
+    inputBinding:
+      prefix: --optional_param1
 outputs:
   - id: single_output_file
     type: File

--- a/src/test_tdl/ParamDocumentToCWL_test.cpp
+++ b/src/test_tdl/ParamDocumentToCWL_test.cpp
@@ -170,9 +170,7 @@ void testComplexCall() {
       prefix: --single_input_file
   - doc: no doc
     id: multi_input_file
-    type:
-      items: File
-      type: array
+    type: File[]
     inputBinding:
       prefix: --multi_input_file
   - doc: no doc
@@ -215,9 +213,7 @@ outputs:
     outputBinding:
       glob: $(inputs.prefixed_output_file)*
   - id: prefixed_output_files
-    type:
-      items: File
-      type: array
+    type: File[]
     outputBinding:
       glob: $(inputs.prefixed_output_files)*
   - id: single_output_dir


### PR DESCRIPTION
This adds some neat usage of compact types:
 - single optional types are now compacted to `type: string?`
 - array types are now compacted to `type: string[]`
 - and optional array types are now compacted to `type: string[]?`.
 
Unit tests for all of these were added.