### PR TITLE
[INFRA] install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------------------------------
-# Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
-# Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file.
 # -----------------------------------------------------------------------------------------------------
@@ -15,27 +15,29 @@ cmake_minimum_required (VERSION 3.15)
 
 # check if this is the root project (
 if (NOT DEFINED PROJECT_NAME)
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-    set(TDL_ROOT_PROJECT TRUE)
+    set (CMAKE_CXX_STANDARD 17)
+    set (CMAKE_CXX_STANDARD_REQUIRED ON)
+    set (CMAKE_CXX_EXTENSIONS OFF)
+    set (TDL_ROOT_PROJECT TRUE)
 endif ()
 
-project (tdl LANGUAGES CXX VERSION "${TDL_PROJECT_VERSION}"
-             DESCRIPTION "tdl -- tool description library")
+include (cmake/version.cmake)
 
-include(tdl-config.cmake)
+project (tdl
+         LANGUAGES CXX
+         VERSION "${TDL_VERSION}"
+         DESCRIPTION "tdl -- tool description library")
 
+include (tdl-config.cmake)
 
 # Enable and include testing if this is a root directory
 if (${TDL_ROOT_PROJECT})
-    enable_testing()
-    file(GLOB TEST_CPP_FILES
-         LIST_DIRECTORIES false
-         RELATIVE ${PROJECT_SOURCE_DIR}
-         CONFIGURE_DEPENDS
-         src/test_tdl/*.cpp)
-    add_executable(test_tdl ${TEST_CPP_FILES})
-    target_link_libraries(test_tdl tdl)
-    add_test(NAME test_tdl COMMAND test_tdl)
-endif()
+    enable_testing ()
+    file (GLOB TEST_CPP_FILES
+          LIST_DIRECTORIES false
+          RELATIVE ${PROJECT_SOURCE_DIR}
+          CONFIGURE_DEPENDS src/test_tdl/*.cpp)
+    add_executable (test_tdl ${TEST_CPP_FILES})
+    target_link_libraries (test_tdl tdl::tdl)
+    add_test (NAME test_tdl COMMAND test_tdl)
+endif ()

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,33 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file.
+# -----------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.12)
+
+include (${CMAKE_CURRENT_LIST_DIR}/version.cmake)
+include (GNUInstallDirs)
+
+install (TARGETS tdl
+         EXPORT tdl_targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install (DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../src/tdl" TYPE INCLUDE)
+install (EXPORT tdl_targets
+         NAMESPACE tdl::
+         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tdl
+         FILE tdl-config.cmake)
+
+include (CMakePackageConfigHelpers)
+set (version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/tdl-config-version.cmake")
+write_basic_package_version_file (
+    ${version_file}
+    VERSION "${TDL_VERSION}"
+    COMPATIBILITY AnyNewerVersion)
+install (FILES ${version_file} DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tdl)
+
+install (FILES "${CMAKE_CURRENT_LIST_DIR}/../LICENSE.md" "${CMAKE_CURRENT_LIST_DIR}/../README.md" TYPE DOC)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,8 @@
+# -----------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file.
+# -----------------------------------------------------------------------------------------------------
+
+set (TDL_VERSION "1.0.1")

--- a/tdl-config.cmake
+++ b/tdl-config.cmake
@@ -1,39 +1,54 @@
 # -----------------------------------------------------------------------------------------------------
-# Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
-# Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file.
 # -----------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.12)
 if (TARGET tdl)
-    return()
-endif()
+    return ()
+endif ()
+
+option (INSTALL_TDL "Enable installation of TDL. (Projects embedding TDL may want to turn this OFF.)" ON)
 
 find_package (yaml-cpp QUIET)
-
 if (NOT yaml-cpp_FOUND)
-    message (STATUS "Fetching yaml-cpp")
+    if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+        message (STATUS "Fetching yaml-cpp")
+    endif ()
 
     include (FetchContent)
     FetchContent_Declare (
         yaml-cpp_fetch_content
         GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
-        GIT_TAG "yaml-cpp-0.7.0")
+        # !WORKAROUND git tag 0.7.0 can't be properly installed due to missing CMake
+        GIT_TAG "35b4498026b6293bfadc75f9ee325cb16d6975af")
     option (YAML_CPP_BUILD_CONTRIB "" OFF)
     option (YAML_CPP_BUILD_TOOLS "" OFF)
     option (YAML_BUILD_SHARED_LIBS "" OFF)
-    option (YAML_CPP_INSTALL "" ON)
+    option (YAML_CPP_INSTALL "" ${INSTALL_TDL})
+    option (YAML_CPP_BUILD_TESTS "" OFF)
     set_property (GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
     FetchContent_MakeAvailable (yaml-cpp_fetch_content)
-    target_compile_options (yaml-cpp PRIVATE "-w")
 else ()
-    message (STATUS "Found yaml-cpp ${yaml-cpp_VERSION}")
+    if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+        message (STATUS "Found yaml-cpp")
+    endif ()
 endif ()
 
-add_library(tdl INTERFACE)
-target_include_directories(tdl INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-    $<INSTALL_INTERFACE:include>)
-target_link_libraries(tdl INTERFACE yaml-cpp)
+add_library (tdl INTERFACE)
+target_include_directories (tdl INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>"
+                                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+# !WORKAROUND yaml-cpp::yaml-cpp was only defined after the 0.7.0 release
+# yaml-cpp::yaml-cpp is required to correctly link against a fetch_content'ed yaml-cpp
+if (TARGET yaml-cpp::yaml-cpp)
+    target_link_libraries (tdl INTERFACE yaml-cpp::yaml-cpp)
+else ()
+    target_link_libraries (tdl INTERFACE yaml-cpp)
+endif ()
 add_library (tdl::tdl ALIAS tdl)
+
+if (INSTALL_TDL)
+    include (${CMAKE_CURRENT_LIST_DIR}/cmake/install.cmake)
+endif ()


### PR DESCRIPTION
This modifies the install target such that the tdl can be installed and found via find_package. If yaml-cpp is not available, it will also be installed.

https://github.com/seqan/sharg-parser/pull/202