### PR TITLE
fix build for GCC on Windows

### DIFF
--- a/src/tdl/convertToCTD.h
+++ b/src/tdl/convertToCTD.h
@@ -16,7 +16,7 @@
 #include <sstream>
 
 
-#if defined(_WIN32) || defined(WIN32)
+#if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUG__)
 #   // Maybe visual studio will get there one day to support the c++ standard...
 #   // Until then we have to live with this:
 #   define and &&
@@ -356,7 +356,7 @@ inline auto convertToCTD(ToolInfo const& doc) {
 
 }
 
-#if defined(_WIN32) || defined(WIN32)
+#if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUG__)
 #undef and
 #undef or
 #undef not

--- a/src/tdl/convertToCWL.h
+++ b/src/tdl/convertToCWL.h
@@ -19,7 +19,7 @@
 #include <sstream>
 
 
-#if defined(_WIN32) || defined(WIN32)
+#if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUG__)
 #   // Maybe visual studio will get there one day to support the c++ standard...
 #   // Until then we have to live with this:
 #   define and &&
@@ -369,7 +369,7 @@ inline auto convertToCWL(ToolInfo const& doc) -> std::string {
 
 }
 
-#if defined(_WIN32) || defined(WIN32)
+#if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUG__)
 #undef and
 #undef or
 #undef not


### PR DESCRIPTION
The directives defining `and`/`or`/`not` for MSVC breaks GCC builds on Windows. In this PR, I add an additional check for `__GNUG__` which is always defined for GNU C++ builds. This fixes my build with MinGW-w64.