### PR TITLE
[FIX] Appending basecommand multiple times

### DIFF
--- a/src/tdl/convertToCWL.h
+++ b/src/tdl/convertToCWL.h
@@ -278,7 +278,7 @@ inline void f(Node::Children const& children, ToolInfo const& doc, InputCB const
                     inputs.push_back(input);
                 } , [&](auto output) {
                     outputs.push_back(output);
-                }, baseCommandCB);
+                }, [](auto){});
 
                 auto inputType  = cwl::CommandInputRecordSchema{};
                 auto outputType = cwl::CommandOutputRecordSchema{};


### PR DESCRIPTION
When there are multiple recursions, the baseCommandCB would be called multiple times:

```
baseCommand:
  - readme_sneak_peek_snippet
  - TEST
  - remote
  - set-url
  - set-url // Duplicate
  - remote  // Duplicate
  - set-url // Duplicate
  - set-url // Duplicate
```

```
baseCommand:
  - readme_sneak_peek_snippet
  - remote
  - set-url
  - set-url // Duplicate
```
