### PR TITLE
infra: update CI

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -25,7 +25,8 @@ defaults:
 jobs:
   build:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
@@ -37,9 +38,7 @@ jobs:
           - name: "Install (no yaml-cpp)"
             yaml_cpp: false
     container:
-      image: ghcr.io/seqan/gcc-14
-      volumes:
-        - /home/runner:/home/runner
+      image: ghcr.io/seqan/gcc-second-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,4 +72,4 @@ jobs:
           cmake ../src/test_tdl/example -DCMAKE_BUILD_TYPE=Release \
                                         -DTDL_INSTALL_DIR="${TDL_INSTALL_DIR}/usr/local"
           make -k
-          ctest . -j --output-on-failure
+          ctest . -j --output-on-failure --no-tests=error

--- a/.github/workflows/ci_codeql.yml
+++ b/.github/workflows/ci_codeql.yml
@@ -25,6 +25,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     permissions:
       security-events: write

--- a/.github/workflows/ci_license_check.yml
+++ b/.github/workflows/ci_license_check.yml
@@ -11,9 +11,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: license-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -25,31 +25,29 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     name: ${{ matrix.compiler }} C++${{ matrix.cpp }} ${{ matrix.build_type }}
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
-        compiler: ["clang-20", "clang-19", "clang-18", "clang-17", "gcc-14", "gcc-13", "gcc-12", "intel"]
+        compiler: ["clang-latest", "clang-second-latest", "clang-third-latest", "gcc-latest", "gcc-second-latest", "gcc-third-latest", "intel"]
         cpp: [17, 20, 23, 26]
         build_type: [Release, Debug]
         exclude:
-          - compiler: clang-16
-            cpp: 26
-          - compiler: gcc-13
-            cpp: 26
-          - compiler: gcc-12
-            cpp: 26
-          - compiler: gcc-11
+          - compiler: gcc-third-latest
             cpp: 26
         include:
-          - compiler: gcc-14
+          - compiler: gcc-latest
             cpp: 17
+            build_type: Release
+            cpp_flags: "-Wno-maybe-uninitialized"
+          - compiler: gcc-second-latest
+            cpp: 17
+            build_type: Release
             cpp_flags: "-Wno-maybe-uninitialized"
     container:
       image: ghcr.io/seqan/${{ matrix.compiler }}
-      volumes:
-        - /home/runner:/home/runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,5 +65,5 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        run: ctest . -j --output-on-failure
+        run: ctest . -j --output-on-failure --no-tests=error
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -24,20 +24,27 @@ defaults:
 
 jobs:
   build:
-    name: ${{ matrix.os }} ${{ matrix.compiler }} C++${{ matrix.cpp }} ${{ matrix.build_type }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
+    name: ${{ matrix.compiler }} C++${{ matrix.cpp }} ${{ matrix.build_type }}
+    runs-on: macos-latest
+    timeout-minutes: 60
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
-        compiler: ["clang-19", "clang-18", "clang-17", "gcc-14", "gcc-13", "gcc-12"]
-        cpp: [17]
-        build_type: [Release]
-        os: ["macos-13", "macos-14"]
+        compiler: ["clang-latest", "clang-second-latest", "clang-third-latest", "gcc-latest", "gcc-second-latest", "gcc-third-latest"]
+        cpp: [17, 26]
+        build_type: [Release, Debug]
+        exclude:
+          - compiler: gcc-third-latest
+            cpp: 26
         include:
-          - compiler: gcc-14
+          - compiler: gcc-latest
             cpp: 17
+            build_type: Release
+            cpp_flags: "-Wno-maybe-uninitialized"
+          - compiler: gcc-second-latest
+            cpp: 17
+            build_type: Release
             cpp_flags: "-Wno-maybe-uninitialized"
     steps:
       - name: Checkout
@@ -61,4 +68,4 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        run: ctest . -j --output-on-failure
+        run: ctest . -j --output-on-failure --no-tests=error

--- a/.github/workflows/ci_mingw.yml
+++ b/.github/workflows/ci_mingw.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: windows-2022
+    timeout-minutes: 60
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
@@ -55,4 +56,4 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        run: PATH="/c/mingw64/bin/:${PATH}" ctest . -j --output-on-failure
+        run: PATH="/c/mingw64/bin/:${PATH}" ctest . -j --output-on-failure --no-tests=error

--- a/.github/workflows/ci_sanitizer.yml
+++ b/.github/workflows/ci_sanitizer.yml
@@ -27,6 +27,7 @@ defaults:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     name: ${{ matrix.name }} ${{ matrix.build_type }} ${{ matrix.os }}
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     env:
@@ -35,46 +36,40 @@ jobs:
       fail-fast: false
       matrix:
         name: [ASan, TSan, UBSan]
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-latest]
         build_type: [Release, Debug]
         exclude:
           - name: "TSan"
-            os: macos-14
+            os: macos-latest
         include:
+          - os: macos-latest
+            compiler: clang-latest
+          - os: ubuntu-latest
+            compiler: gcc-latest
+            image: ghcr.io/seqan/gcc-latest
+
           - name: "ASan"
             os: ubuntu-latest
             cxx_flags: "-fsanitize=address -Wno-maybe-uninitialized"
-
           - name: "ASan"
-            os: macos-14
+            os: macos-latest
             cxx_flags: "-fsanitize=address"
 
           - name: "TSan"
+            os: ubuntu-latest
+            compiler: clang-latest
+            image: ghcr.io/seqan/clang-latest
             cxx_flags: "-fsanitize=thread"
 
           - name: "UBSan"
             os: ubuntu-latest
             cxx_flags: "-fsanitize=undefined,float-divide-by-zero"
-
           - name: "UBSan"
-            os: macos-14
+            os: macos-latest
             cxx_flags: "-fsanitize=undefined,float-divide-by-zero,implicit-conversion,local-bounds,nullability"
 
-          - os: macos-14
-            compiler: clang-19
-
-          - os: ubuntu-latest
-            compiler: gcc-14
-            image: ghcr.io/seqan/gcc-14
-
-          - name: "TSan"
-            os: ubuntu-latest
-            compiler: clang-19
-            image: ghcr.io/seqan/clang-19
     container:
       image: ${{ matrix.image || '' }}
-      volumes:
-        - /home/runner:/home/runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,5 +93,5 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        run: ctest . -j --output-on-failure
+        run: ctest . -j --output-on-failure --no-tests=error
 

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -21,27 +21,26 @@ env:
 jobs:
   build:
     name: ${{ matrix.name }}
-    runs-on: windows-${{ matrix.version }}
-    timeout-minutes: 180
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     if: github.repository_owner == 'deNBI-cibi' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: "Visual Studio 17 2022"
-            version: 2022
-            build_type: Release
-            cpp: 17
+          #  Once VS2025 is released :)
+          # - name: "Visual Studio 17 2025"
+          #   os: windows-2025
+          #   build_type: Release
+          #   cpp: 17
 
-          - name: "Visual Studio 16 2019"
-            version: 2019
+          - name: "Visual Studio 17 2022"
+            os: windows-2022
             build_type: Release
             cpp: 17
     steps:
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
-        with:
-          vsversion: ${{ matrix.version }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,4 +59,4 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        run: ctest . -j -C "${{ matrix.build_type }}" --output-on-failure --timeout 240
+        run: ctest . -j -C "${{ matrix.build_type }}" --output-on-failure --no-tests=error --timeout 240


### PR DESCRIPTION
* Use generic compiler/image names for macOS and linux
* windows-2019 is no longer supported

Todo:
* [x] fix failures
* [x] update required jobs for ci